### PR TITLE
Make service_alias public

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -170,6 +170,7 @@ class OldSoundRabbitMqExtension extends Extension
                 $this->container->setDefinition($producerServiceName, $definition);
                 if (null !== $producer['service_alias']) {
                     $this->container->setAlias($producer['service_alias'], $producerServiceName);
+                    $this->container->getAlias($producer['service_alias'])->setPublic(true);
                 }
             }
         } else {


### PR DESCRIPTION
Symfony 4 makes all services private by default. 

We can assume that when we use service_alias we want that service to be public, so I made this little change.